### PR TITLE
disable webpack-bundle-analyzer open on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Current
+
+## Enhancements
+- disable webpack-bundle-analyzer open on startup
+
 # 0.1.2
 
 ## Enhancements

--- a/build/webpack.dev.conf.js
+++ b/build/webpack.dev.conf.js
@@ -67,7 +67,9 @@ const devWebpackConfig = merge(baseWebpackConfig, {
         ignore: ['.*']
       }
     ]),
-    new BundleAnalyzerPlugin()
+    new BundleAnalyzerPlugin({
+      openAnalyzer: false
+    })
   ]
 })
 


### PR DESCRIPTION
Disable webpack-bundle-analyzer opening report on npm start, for convenience reasons. Report is still accessible on plugin' local server.